### PR TITLE
Upgrade to focal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/ghrocker.egg-info/*
+dist
+*__pycache__*

--- a/src/ghrocker/ghrocker.py
+++ b/src/ghrocker/ghrocker.py
@@ -56,7 +56,7 @@ def main():
     active_extensions = extension_manager.get_active_extensions(args_dict)
     print("Active extensions %s" % [e.get_name() for e in active_extensions])
 
-    dig = DockerImageGenerator(active_extensions, args_dict, 'ubuntu:bionic')
+    dig = DockerImageGenerator(active_extensions, args_dict, 'ubuntu:focal')
 
     exit_code = dig.build(**vars(args))
     if exit_code != 0:

--- a/src/ghrocker/templates/ghpages_snippet.Dockerfile.em
+++ b/src/ghrocker/templates/ghpages_snippet.Dockerfile.em
@@ -1,6 +1,6 @@
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -q -y curl net-tools python python-yaml build-essential nodejs ruby-full autoconf automake libtool pkg-config zlib1g-dev
-RUN echo "gem: --no-ri --no-rdoc" > ~/.gemrc
+RUN echo "gem: --no-document" > ~/.gemrc
 RUN gem install bundler
 RUN gem install jekyll
 RUN gem install github-pages


### PR DESCRIPTION
Several dependencies in ruby dropped ruby 2.5 support. Moving forward is easier than pinning lots of things.