### PR TITLE
Change ghrocker to use a prebuilt image by default

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -43,8 +43,8 @@ jobs:
           file: Dockerfile.ghrocker
           load: true
           push: true
-          tags:
-            - ghcr.io/tfoote/ghrocker/ghrocker:latest
-            - ghcr.io/tfoote/ghrocker/ghrocker:${{ steps.date.outputs.date }}
+          tags: |
+            ghcr.io/tfoote/ghrocker/ghrocker:latest
+            ghcr.io/tfoote/ghrocker/ghrocker:${{ steps.date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -32,14 +32,19 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       -
-        name: Build estimator
+        name: Build ghrocker Image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.ghrocker
           load: true
           push: true
-          tags: ghcr.io/tfoote/ghrocker/ghrocker:baseline
+          tags:
+            - ghcr.io/tfoote/ghrocker/ghrocker:latest
+            - ghcr.io/tfoote/ghrocker/ghrocker:${{ steps.date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,7 +1,7 @@
 name: build_packages
 on:
   push:
-    branches: [ main ]
+  pr:
 defaults:
   run:
     shell: bash
@@ -42,7 +42,7 @@ jobs:
           context: .
           file: Dockerfile.ghrocker
           load: true
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
             ghcr.io/tfoote/ghrocker/ghrocker:latest
             ghcr.io/tfoote/ghrocker/ghrocker:${{ steps.date.outputs.date }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,7 +1,7 @@
 name: build_packages
 on:
   push:
-  pr:
+  pull-request:
 defaults:
   run:
     shell: bash

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,45 @@
+name: build_packages
+on:
+  push:
+    # branches: [ main ]
+defaults:
+  run:
+    shell: bash
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+      - name: Install ghrocker
+        run: |
+          pip install .
+      - name: Generate Dockerfile
+        run: |
+          ghrocker --dockerfile-only . 
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build estimator
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.ghrocker
+          load: true
+          push: true
+          tags: ghcr.io/tfoote/ghrocker/ghrocker:baseline
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,7 +1,7 @@
 name: build_packages
 on:
   push:
-    # branches: [ main ]
+    branches: [ main ]
 defaults:
   run:
     shell: bash

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,7 +1,7 @@
 name: build_packages
 on:
   push:
-  pull-request:
+  pull_request:
 defaults:
   run:
     shell: bash

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -21,7 +21,7 @@ jobs:
           pip install .
       - name: Generate Dockerfile
         run: |
-          ghrocker --dockerfile-only . 
+          generate_ghrocker_dockerfile
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -15,7 +15,9 @@ jobs:
       - name: Install ghrocker
         run: |
           pip install .
-      - name: Test build
+      - name: Test prebuilt
         run: |
-          pwd
           ghrocker --build -- test/test_site
+      - name: Test local build
+        run: |
+          ghrocker --build --develop -- test/test_site

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,7 +1,24 @@
 name: test_build
 on: [push, pull_request]
 jobs:
-  Run-Test-Build:
+  Test_Local-Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+      - name: Install ghrocker
+        run: |
+          pip install .
+      - name: Test local build
+        run: |
+          ghrocker --build --develop -- test/test_site
+  Test-Prebuilt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,6 +35,21 @@ jobs:
       - name: Test prebuilt
         run: |
           ghrocker --build -- test/test_site
-      - name: Test local build
+
+  dockerfile-generation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
         run: |
-          ghrocker --build --develop -- test/test_site
+          python -m pip install --upgrade pip
+      - name: Install ghrocker
+        run: |
+          pip install .
+      - name: Test Generation
+        run: |
+          generate_ghrocker_dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ src/ghrocker.egg-info/*
 build
 dist
 *__pycache__*
+test/test_site/_site
+test/test_site/Gemfile.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 
 [project.scripts]
 ghrocker = "ghrocker.ghrocker:main"
+generate_ghrocker_dockerfile = "ghrocker.ghrocker:generate_dockerfile"
 
 [project.entry-points."rocker.extensions"]
 ghpages = "ghrocker.ghpages_extension:GHPages"

--- a/src/ghrocker/ghrocker.py
+++ b/src/ghrocker/ghrocker.py
@@ -24,6 +24,7 @@ def main():
     parser.add_argument('-v', '--version', action='version',
         version='%(prog)s ' + get_rocker_version())
     parser.add_argument('--build-only', action='store_true')
+    parser.add_argument('--dockerfile-only', action='store_true')
     parser.add_argument('--debug-inside', action='store_true')
     # TODO(tfoote) add verbose parser.add_argument('--verbose', action='store_true')
 
@@ -56,6 +57,11 @@ def main():
     print("Active extensions %s" % [e.get_name() for e in active_extensions])
 
     dig = DockerImageGenerator(active_extensions, args_dict, 'ruby:3.1-bookworm')
+
+    if args.dockerfile_only:
+        with open('Dockerfile.ghrocker', 'w') as fh:
+            fh.write(dig.dockerfile)
+        return True
 
     exit_code = dig.build(**vars(args))
     if exit_code != 0:

--- a/src/ghrocker/ghrocker.py
+++ b/src/ghrocker/ghrocker.py
@@ -61,7 +61,7 @@ def main():
     if args.dockerfile_only:
         with open('Dockerfile.ghrocker', 'w') as fh:
             fh.write(dig.dockerfile)
-        return True
+        return 0
 
     exit_code = dig.build(**vars(args))
     if exit_code != 0:

--- a/src/ghrocker/ghrocker.py
+++ b/src/ghrocker/ghrocker.py
@@ -24,7 +24,6 @@ def main():
     parser.add_argument('-v', '--version', action='version',
         version='%(prog)s ' + get_rocker_version())
     parser.add_argument('--build-only', action='store_true')
-    parser.add_argument('--dockerfile-only', action='store_true')
     parser.add_argument('--debug-inside', action='store_true')
     # TODO(tfoote) add verbose parser.add_argument('--verbose', action='store_true')
 
@@ -57,10 +56,6 @@ def main():
     print("Active extensions %s" % [e.get_name() for e in active_extensions])
 
     dig = DockerImageGenerator(active_extensions, args_dict, 'ruby:3.1-bookworm')
-    if args.dockerfile_only:
-        with open('Dockerfile.ghrocker', 'w') as fh:
-            fh.write(dig.dockerfile)
-        return 0
 
     #Initialize exit_code
     exit_code = 0
@@ -78,3 +73,26 @@ def main():
         args_dict['command'] = 'bash'
 
     return dig.run(**args_dict)
+
+def generate_dockerfile():
+
+    parser = argparse.ArgumentParser(
+        description='Generate the dockerfile for the prebuilt image',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-v', '--version', action='version',
+        version='%(prog)s ' + get_rocker_version())
+
+    extension_manager = RockerExtensionManager()
+    default_args = {'ghpages': True, 'user': True, 'network': 'host'}
+    extension_manager.extend_cli_parser(parser, default_args)
+
+    args = parser.parse_args()
+    args_dict = vars(args)
+
+    active_extensions = extension_manager.get_active_extensions(args_dict)
+    print("Active extensions %s" % [e.get_name() for e in active_extensions])
+
+    dig = DockerImageGenerator(active_extensions, args_dict, 'ruby:3.1-bookworm')
+    with open('Dockerfile.ghrocker', 'w') as fh:
+        fh.write(dig.dockerfile)
+    return 0


### PR DESCRIPTION
This is much faster and will be more reliable than relying on local builds every time. 

This also adds the automatic generation of the images as a GitHub Action on push to main. 